### PR TITLE
Adding extension point containers to enable extending from external app

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,7 @@
     "vtex.product-summary": "0.x",
     "vtex.menu": "0.x",
     "vtex.minicart": "0.x",
-    "vtex.product-details": "0.x"
+    "vtex.product-details": "0.x",
+    "vtex.storecomponents": "0.x"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "dreamstore",
-  "version": "0.0.11",
+  "version": "0.1.0",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -42,6 +42,9 @@
     "store/search": {
       "component": "SearchPage"
     },
+    "store/search/sections": {
+      "component": "vtex.render/ExtensionContainer"
+    },
     "store/product": {
       "component": "ProductPage"
     },

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -45,7 +45,10 @@
     "store/product": {
       "component": "ProductPage"
     },
-    "store/product/product-details": {
+    "store/product/sections": {
+      "component": "vtex.render/ExtensionContainer"
+    },
+    "store/product/sections/2": {
       "component": "vtex.product-details/ProductDetails"
     }
   }

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -18,14 +18,14 @@
     "store": {
       "component": "StoreTemplate"
     },
-    "store/home": {
-      "component": "HomePage"
-    },
-    "store/home/minicart": {
+    "store/minicart": {
       "component": "vtex.minicart/MiniCart"
     },
-    "store/home/menu-link": {
+    "store/menu-link": {
       "component": "vtex.menu/Menu"
+    },
+    "store/home": {
+      "component": "HomePage"
     },
     "store/home/sections": {
       "component": "vtex.render/ExtensionContainer"

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -27,13 +27,16 @@
     "store/home/menu-link": {
       "component": "vtex.menu/Menu"
     },
-    "store/home/carousel": {
+    "store/home/sections": {
+      "component": "vtex.render/ExtensionContainer"
+    },
+    "store/home/sections/2": {
       "component": "vtex.carousel/Carousel"
     },
-    "store/home/shelf": {
+    "store/home/sections/3": {
       "component": "vtex.shelf/Shelf"
     },
-    "store/home/shelf/shelfitem": {
+    "store/home/sections/3/shelfitem": {
       "component": "vtex.product-summary/ProductSummary"
     },
     "store/search": {

--- a/react/HomePage.js
+++ b/react/HomePage.js
@@ -14,9 +14,7 @@ export default class HomePage extends Component {
   render() {
     return (
       <div className="vtex-dreamstore__container w-100 h-100">
-        <ExtensionPoint id="carousel" />
-        <ExtensionPoint id="shelf" />
-        <ExtensionPoint id="custom" />
+        <ExtensionPoint id="sections" />
       </div>
     )
   }

--- a/react/ProductPage.js
+++ b/react/ProductPage.js
@@ -35,7 +35,7 @@ class ProductPage extends Component {
         ) : (
           <div className="flex flex-column items-center justify-center pv6 pv9-ns">
             <div>
-              <ExtensionPoint id="product-details" slug={variables.slug} />
+              <ExtensionPoint id="sections" slug={variables.slug} />
             </div>
           </div>
         )}

--- a/react/components/Header.js
+++ b/react/components/Header.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 import Input from '@vtex/styleguide/lib/Input'
 import Button from '@vtex/styleguide/lib/Button'
+import SearchBar from 'vtex.storecomponents/SearchBar'
+
 import { ExtensionPoint } from 'render'
 
 import SearchIcon from '../images/SearchIcon'
@@ -39,35 +41,20 @@ class Header extends Component {
         </div>
         <div className="z-2 flex-ns items-center w-100 top-0 pa4 pa5-ns ph7-l bg-white tl">
           <div className="flex items-center justify-between pb3 pb0-ns">
-            <a className="link b f3 near-black tc tl-ns pr7 serious-black" href="/">
+            <a
+              className="link b f3 near-black tc tl-ns pr7 serious-black"
+              href="/"
+            >
               {name || account}
             </a>
           </div>
           <div className="flex items-center flex-auto">
             <div className="w-100 flex ph7-ns">
               <div className="w-100">
-                <Input
+                <SearchBar
                   placeholder={this.translate('search-placeholder')}
-                  value={searchValue}
-                  onChange={this.handleChange}
-                  size="large"
+                  emptyPlaceholder={this.translate('search-emptyPlaceholder')}
                 />
-              </div>
-              <div>
-                <Button
-                  data-test-id="search"
-                  onClick={this.handleSearch}
-                  size="large"
-                >
-                  <div className="flex items-start">
-                    <div>
-                      <SearchIcon />
-                    </div>
-                    <div className="pl3 blue">
-                      SEARCH
-                    </div>
-                  </div>
-                </Button>
               </div>
             </div>
             <div>

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -2,6 +2,7 @@
   "dreamstore.soon": "Soon...",
   "dreamstore.search": "Search",
   "dreamstore.search-placeholder": "Search for products, brands...",
+  "dreamstore.search-emptyPlaceholder": "No matches found",
   "dreamstore.cart": "Cart",
   "dreamstore.buy": "Buy",
   "dreamstore.poweredBy": "POWERED BY"

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -2,6 +2,7 @@
   "dreamstore.soon": "Breve...",
   "dreamstore.search": "Buscar",
   "dreamstore.search-placeholder": "Búsqueda por productos, marcas...",
+  "dreamstore.search-emptyPlaceholder": "Ningún resultado encontrado",
   "dreamstore.cart": "Carrito",
   "dreamstore.buy": "Comprar",
   "dreamstore.poweredBy": "IMPULSADO POR VTEX"

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -2,6 +2,7 @@
   "dreamstore.soon": "Em breve...",
   "dreamstore.search": "Buscar",
   "dreamstore.search-placeholder": "Busque por produtos, marcas...",
+  "dreamstore.search-emptyPlaceholder": "Nenhum resultado encontrado",
   "dreamstore.cart": "Carrinho",
   "dreamstore.buy": "Comprar",
   "dreamstore.poweredBy": "FORNECIDO POR VTEX"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Enables extending from external apps

#### What problem is this solving?
Currently, render does not allow you to define an already defined extension point, so we use an extension container to allow such definitions

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
