### PR TITLE
Fix pages.json to be able to use ExtensionContainer again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.5] - 2018-05-21
 ### Fixed
+- Fix pages dependency to be able to use `ExntesionContainer` again. 
 - `Topbar` when scrolled overlapped the `VTEX-topbar`.
 
 ## [0.3.4] - 2018-05-19

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -33,22 +33,31 @@
     "store/home": {
       "component": "HomePage"
     },
-    "store/home/carousel": {
+    "store/home/sections": {
+      "component": "vtex.render-runtime/ExtensionContainer"
+    },
+    "store/home/sections/1": {
       "component": "vtex.carousel/Carousel"
     },
-    "store/home/shelf": {
+    "store/home/sections/2": {
       "component": "vtex.shelf/Shelf"
     },
     "store/search": {
       "component": "SearchPage"
     },
-    "store/search/gallery": {
+    "store/search/sections": {
+      "component": "vtex.render-runtime/ExtensionContainer"
+    },
+    "store/search/sections/1": {
       "component": "vtex.gallery/Gallery"
     },
     "store/product": {
       "component": "ProductPage"
     },
-    "store/product/product-details": {
+    "store/product/sections": {
+      "component": "vtex.render-runtime/ExtensionContainer"
+    },
+    "store/product/sections/1": {
       "component": "vtex.product-details/ProductDetails"
     }
   }

--- a/react/HomePage.js
+++ b/react/HomePage.js
@@ -14,10 +14,7 @@ export default class HomePage extends Component {
   render() {
     return (
       <div className="vtex-dreamstore__container w-100 h-100">
-        {/* TODO - Investigate issues with ExtensionContainer - @brunojdo - 2018-06-18 */}
-        {/* <ExtensionPoint id="sections" /> */}
-        <ExtensionPoint id="carousel" />
-        <ExtensionPoint id="shelf" />
+        <ExtensionPoint id="sections" />
       </div>
     )
   }

--- a/react/ProductPage.js
+++ b/react/ProductPage.js
@@ -35,7 +35,7 @@ class ProductPage extends Component {
         ) : (
             <div className="pv9-ns">
               <div className="vtex-product-details-container">
-                <ExtensionPoint id="product-details" slug={variables.slug} />
+                <ExtensionPoint id="sections" slug={variables.slug} />
               </div>
             </div>
           )}

--- a/react/components/GalleryWrapper.js
+++ b/react/components/GalleryWrapper.js
@@ -17,14 +17,14 @@ class GalleryWrapper extends Component {
         {loading ? (
           <WrappedSpinner />
         ) : (
-          <div className="w-100">
-            <ExtensionPoint
-              id="gallery"
-              search={query}
-              products={data.products}
-            />
-          </div>
-        )}
+            <div className="w-100">
+              <ExtensionPoint
+                id="sections"
+                search={query}
+                products={data.products}
+              />
+            </div>
+          )}
       </div>
     )
   }

--- a/react/mutations/addToCartMutation.gql
+++ b/react/mutations/addToCartMutation.gql
@@ -1,8 +1,0 @@
-mutation addItem($orderFormId: String, $items: [OrderFormItemInput])
-  @context(scope: "private") {
-  addItem(orderFormId: $orderFormId, items: $items) {
-    items {
-      id
-    }
-  }
-}

--- a/react/mutations/updateItemsMutation.gql
+++ b/react/mutations/updateItemsMutation.gql
@@ -1,6 +1,0 @@
-mutation updateItems($orderFormId: String, $items: [OrderFormItemInput])
-  @context(scope: "private") {
-  updateItems(orderFormId: $orderFormId, items: $items) {
-    orderFormId
-  }
-}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix pages.json to be able to use ExtensionContainer again

**Secondary:** Remove mutations which aren't used anymore.

#### What problem is this solving?
We imported the wrong dependency to use `ExtensionContainer`. 

#### Screenshots or example usage
https://dev--storecomponents.myvtex.com/

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
