### PR TITLE
Change `CategoriesHighlights` to `CategoriesHightlighted`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- `CategoriesHighlights` to `CategoriesHightlighted`.
+
 ### Added
 - DepartmentHeader component to wrap Carousel and MainCategories components.
 - Department page template.

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -125,7 +125,7 @@
           "component": "vtex.carousel/Carousel"
         },
         "header/categories": {
-          "component": "vtex.store-components/CategoriesHighlights"
+          "component": "vtex.store-components/CategoriesHighlighted"
         },
         "results": {
           "component": "vtex.search-result/SearchResult"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change the name of `CategoriesHighlights` to `CategoriesHightlighted`.

Referenced Pull Requests:
- https://github.com/vtex-apps/store-components/pull/134/

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
