### PR TITLE
Allow additional components through ExtensionContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow to import additional components through ExtensionContainer
 
 ### Added
 - DepartmentHeader component to wrap Carousel and MainCategories components.
@@ -13,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.9.4] - 2018-08-02
 ### Changed
-- Bump `vtex.styleguide` major version. 
+- Bump `vtex.styleguide` major version.
 
 ## [1.9.3] - 2018-07-30
 ### Fixed
@@ -25,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.9.1] - 2018-07-24
 ### Changed
-- Bump my-orders version dependency to use stable. 
+- Bump my-orders version dependency to use stable.
 
 ## [1.7.0] - 2018-07-09
 ### Added
@@ -40,7 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Moved `store/login/container` to `vtex.store`.
 
 ## [1.5.0] - 2018-7-6
-### Added 
+### Added
 - `vtex.login/LoginContent` to `store/login/container` extension point.
 
 ## [1.4.0] - 2018-7-6
@@ -55,8 +57,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `pages.json` to inject `search-result` into `CategoryPage`
 
-### Fixed 
-- Remove the integration with `vtex.my-orders-app`. 
+### Fixed
+- Remove the integration with `vtex.my-orders-app`.
 
 ## [1.3.0] - 2018-6-20
 ### Added
@@ -98,7 +100,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Removed redundant Spinner in _ProductPage_ Component.
 
 ### Added
-- **Breaking Change** Now, dreamstore-theme is a template based on `vtex.store`. 
+- **Breaking Change** Now, dreamstore-theme is a template based on `vtex.store`.
 - Add free billing policy in `manifest.json`.
 - Add the breadcrumb component to the `SearchPage` and `ProductPage`.
 
@@ -107,7 +109,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.3.5] - 2018-05-21
 ### Fixed
-- Fix pages dependency to be able to use `ExntesionContainer` again. 
+- Fix pages dependency to be able to use `ExntesionContainer` again.
 - `Topbar` when scrolled overlapped the `VTEX-topbar`.
 - Update css product details class for the spinner be in the center.
 
@@ -156,7 +158,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.0.11] - 2018-05-09
 ### Added
-- Add Product Details app. 
+- Add Product Details app.
 
 ### Deprecated
 - Remove legacy implementations of buy button and minicart.
@@ -170,4 +172,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add Menu app on top bar.
 
 ### Deprecated
-- Remove the own implementation of shelf to add the app. 
+- Remove the own implementation of shelf to add the app.

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -12,7 +12,7 @@
       "component": "vtex.render-runtime/LayoutContainer",
       "context": "vtex.store@1.x/StoreContextProvider",
       "props": {
-        "elements": ["header", "__children__", "footer"]
+        "elements": ["header", "__children__", "footer", "additionalComponent"]
       },
       "extensions": {
         "header": {
@@ -32,6 +32,9 @@
         },
         "footer": {
           "component": "vtex.store-components/Footer"
+        },
+        "additionalComponent": {
+          "component": "vtex.render-runtime/ExtensionContainer"
         }
       }
     },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Allow to import additional components through ExtensionContainer.

#### What problem is this solving?

The stores can add non related components without needed to fork the dreamstore.

#### Screenshots or example usage
`{
  "extensions": {
    "store/additionalComponent": {
      "component": "MyComponent"
    }
  }
}`

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
