### PR TITLE
Remove unused dependency vtex.product-summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Unused dependency `vtex.product-summary`
 
 ## [1.12.2] - 2018-08-30
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "vtex.store-graphql": "2.x",
     "vtex.shelf": "0.x",
-    "vtex.product-summary": "0.x",
     "vtex.menu": "1.x",
     "vtex.minicart": "1.x",
     "vtex.my-orders-app": "1.x",


### PR DESCRIPTION
#### What is the purpose of this pull request?
- remove unused dependency `vtex.product-summary`

#### How should this be manually tested?
https://claudivan3--storecomponents.myvtex.com/

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
