### PR TITLE
Add Logo and SearchBar as extensions of the Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.14.0] - 2018-09-14
 ### Added
 - `Logo` and `SearchBar` as extensions of the `Header`. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `Logo` and `SearchBar` as extensions of the `Header`. 
 
 ## [1.13.3] - 2018-09-12
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "dreamstore",
-  "version": "1.13.3",
+  "version": "1.14.0",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -37,6 +37,9 @@
         "header/logo": {
           "component": "vtex.store-components/Logo"
         },
+        "header/search-bar": {
+          "component": "vtex.store-components/SearchBar"
+        },
         "footer": {
           "component": "vtex.store-components/Footer"
         }

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -34,6 +34,9 @@
         "header/category-menu": {
           "component": "vtex.category-menu/index"
         },
+        "header/logo": {
+          "component": "vtex.store-components/Logo"
+        },
         "footer": {
           "component": "vtex.store-components/Footer"
         }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the Logo and SearchBar as extensions of the Header.

OBS.: It should be released BEFORE this [PR](https://github.com/vtex-apps/store-components/pull/163).

#### How should this be manually tested?
[Access the workspace.](https://waza3--storecomponents.myvtex.com/)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [X] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
