### PR TITLE
Move breadcrumb inside the product details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.15.1] - 2018-09-19
 ### Changed
 - Moved product details breadcrumb to be inside of the `ProductDetails`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Moved product details breadcrumb to be inside of the `ProductDetails`.
 
 ## [1.15.0] - 2018-09-18
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "dreamstore",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -53,18 +53,17 @@
       "context": "vtex.store@1.x/ProductContextProvider",
       "props": {
         "elements": [
-          "breadcrumb",
           "details",
           "kit",
           "related"
         ]
       },
       "extensions": {
-        "breadcrumb": {
-          "component": "vtex.breadcrumb/Breadcrumb"
-        },
         "details": {
           "component": "vtex.product-details/ProductDetails"
+        },
+        "details/breadcrumb": {
+          "component": "vtex.breadcrumb/Breadcrumb"
         },
         "kit": {
           "component": "vtex.product-kit/ProductKit"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Move the breadcrumb inside an extension point of the product details.

#### What problem is this solving?
The breadcrumb need to be inside a element with the class `vtex-page-padding` and since the search result is already containing it's own breadcrumb, 

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/nintendo-switch/p).

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
