### PR TITLE
Add Telemarketing app to the Header extension point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Back with telemarketing app.
 
 ## [1.14.0] - 2018-09-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Back with telemarketing app.
-
+- Add again Telemarketing app to the Header extension point.
 ## [1.14.0] - 2018-09-14
 ### Added
 - `Logo` and `SearchBar` as extensions of the `Header`. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.14.1] - 2018-09-18
 ### Added
 - Add again Telemarketing app to the Header extension point.
 ## [1.14.0] - 2018-09-14

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "dreamstore",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -22,6 +22,9 @@
         "header": {
           "component": "vtex.store-components/Header"
         },
+        "header/telemarketing": {
+          "component": "vtex.telemarketing/index"
+        },
         "header/minicart": {
           "component": "vtex.minicart/MiniCart"
         },


### PR DESCRIPTION
Depends on: https://github.com/vtex-apps/telemarketing/pull/8

#### Screenshots or example usage
https://bruno--storecomponents.myvtex.com/

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
