### PR TITLE
Add component definitions for search ep's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.18.0] - 2018-10-02
 ### Added
 - Component definitions for `vtex.search-result` new extension points.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Component definitions for `vtex.search-result` new extension points.
 
 ## [1.17.0] - 2018-10-02
 ### Removed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "dreamstore",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,7 @@
     "vtex.product-details": "0.x",
     "vtex.product-summary": "1.x",
     "vtex.store-components": "2.x",
-    "vtex.search-result": "1.x",
+    "vtex.search-result": "2.x",
     "vtex.category-menu": "1.x",
     "vtex.breadcrumb": "0.x",
     "vtex.login": "1.x",

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,7 @@
     "vtex.minicart": "1.x",
     "vtex.my-account": "0.x",
     "vtex.product-details": "0.x",
+    "vtex.product-summary": "1.x",
     "vtex.store-components": "2.x",
     "vtex.search-result": "1.x",
     "vtex.category-menu": "1.x",

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -153,30 +153,6 @@
           "container"
         ]
       }
-    },
-    "department": {
-      "component": "vtex.render-runtime/LayoutContainer",
-      "context": "vtex.store@1.x/ProductSearchContextProvider",
-      "props": {
-        "elements": [
-          "header",
-          "results"
-        ]
-      },
-      "extensions": {
-        "header": {
-          "component": "vtex.render-runtime/ExtensionContainer"
-        },
-        "header/carousel": {
-          "component": "vtex.carousel/Carousel"
-        },
-        "header/categories": {
-          "component": "vtex.store-components/CategoriesHighlights"
-        },
-        "results": {
-          "component": "vtex.search-result/index"
-        }
-      }
     }
   },
   "pages": {
@@ -219,7 +195,7 @@
     "store/department": [
       {
         "name": "Default",
-        "template": "department"
+        "template": "search"
       }
     ],
     "store/category": [

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -91,6 +91,15 @@
         },
         "results/breadcrumb": {
           "component": "vtex.breadcrumb/Breadcrumb"
+        },
+        "results/gallery": {
+          "component": "vtex.search-result/Gallery"
+        },
+        "results/gallery/product-summary": {
+          "component": "vtex.product-summary/index"
+        },
+        "results/filter-navigator": {
+          "component": "vtex.search-result/FilterNavigator"
         }
       }
     },


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add definitions for the `results/gallery`, `results/filter-navigator`, and `results/gallery/product-summary`.

#### What problem is this solving?
The search is now being moved to use EP only, instead of directly referencing the components.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/eletronicos/smartphones).

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
