### PR TITLE
Add product-summary extension in header/minicart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
 - Dreamstore with Design Tokens! :tada 
 - Extension point definition for not found results page.
 - Add `ProductSummary` to `header/minicart/product-summary` extension point.
-
 
 ## [1.18.5] - 2018-11-23
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
 - Dreamstore with Design Tokens! :tada 
 - Extension point definition for not found results page.
+- Add `ProductSummary` to `header/minicart/product-summary` extension point.
+
 
 ## [1.18.5] - 2018-11-23
 ### Changed

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -31,6 +31,9 @@
         "header/minicart": {
           "component": "vtex.minicart/MiniCart"
         },
+        "header/minicart/product-summary": {
+          "component": "vtex.product-summary/index"
+        },
         "header/login": {
           "component": "vtex.login/Login"
         },


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the product-summary extension in pages.json

<!--- Describe your changes in detail. -->

#### What problem is this solving?
Adding an extension in header to  load the product-summary in the minicart


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
