### PR TITLE
Add profile challenge block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.0-rc] - 2019-01-28
 ### Added
 - Add profile challenge block on account.
-
-## [2.0.0-beta.16] - 2019-01-24
-
-## [2.0.0-beta.15] - 2019-01-24
-
-## [2.0.0-beta.14] - 2019-01-23
-
-### Added
 - Bye `pages.json`! Welcome `store-builder`.
 - Two new nav icons.
 - New Icon for telemarketing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add profile challenge block on account.
 
 ## [2.0.0-beta.16] - 2019-01-24
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "dreamstore",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-rc",
   "builders": {
     "styles": "0.x",
     "store": "0.x"

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
     "postreleasy": "vtex publish --verbose"
   },
   "dependencies": {
-    "vtex.store": "2.0.0-beta.11",
+    "vtex.store": "2.0.0-rc",
     "vtex.store-header": "2.x",
     "vtex.store-footer": "2.x",
     "vtex.carousel": "2.x",

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -40,7 +40,10 @@
   "store.account": {
     "blocks": [
       "my-account"
-    ]
+    ],
+    "parent": {
+      "challenge": "challenge.profile"
+    }
   },
   "store.login": {
     "blocks": [


### PR DESCRIPTION
#### What is the purpose of this pull request?
Override the challenge block on the `store.account` to use the `ProfileChallenge`.

#### What problem is this solving?
The account path won't have authentication without this.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/) (I can't link the dreamstore).

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
