### PR TITLE
Set ProductName tag as h2 in Shelf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Set `ProductName` tag as `h2` in `Shelf`.
 
 ## [2.0.0] - 2019-02-01
 

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -255,7 +255,8 @@
           "name": {
             "showBrandName": false,
             "showSku": false,
-            "showProductReference": false
+            "showProductReference": false,
+            "tag": "h2"
           }
         }
       }


### PR DESCRIPTION
#### What is the purpose of this pull request?
We basically do not use header elements (h1, h2, h3) in our components and it is desirable to use these elements to make our html codebase more meaningful (by adding semantic html elements).

<!--- Describe your changes in detail. -->

#### What problem is this solving?
`product-summary` `ProductName` in `shelf`  used as H2 element instead of a div.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
[Here](https://alves--storecomponents.myvtex.com/)

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
